### PR TITLE
Index dot-files on composes.centos.org

### DIFF
--- a/templates/30_composes.conf.j2
+++ b/templates/30_composes.conf.j2
@@ -7,7 +7,7 @@
  AddDescription "{{ inventory_hostname }}" server.id
  ReadmeName /centos-design/footer.html
  HeaderName /centos-design/header-centos-mirror.html
- IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t FOOTER.html
+ IndexIgnore *~ *# HEADER* README* RCS CVS *,v *,t FOOTER.html
 
  # Rewrite Rules coming from Ansible/inventory
  RewriteEngine On

--- a/templates/30_composes.conf.j2
+++ b/templates/30_composes.conf.j2
@@ -7,6 +7,7 @@
  AddDescription "{{ inventory_hostname }}" server.id
  ReadmeName /centos-design/footer.html
  HeaderName /centos-design/header-centos-mirror.html
+ IndexIgnoreReset ON
  IndexIgnore *~ *# HEADER* README* RCS CVS *,v *,t FOOTER.html
 
  # Rewrite Rules coming from Ansible/inventory

--- a/templates/ssl-composes.conf.j2
+++ b/templates/ssl-composes.conf.j2
@@ -4,7 +4,7 @@
  DocumentRoot {{ composes_local_dir }}
  #ReadmeName /centos-design/footer.html
  HeaderName /centos-design/header-centos-composes-mirror.html
- IndexIgnore .??* *~ *# HEADER* README* RCS CVS *,v *,t FOOTER.html
+ IndexIgnore *~ *# HEADER* README* RCS CVS *,v *,t FOOTER.html
 
  Header always set Strict-Transport-Security "max-age=31536000"
  Header always set X-Xss-Protection "1; mode=block"

--- a/templates/ssl-composes.conf.j2
+++ b/templates/ssl-composes.conf.j2
@@ -4,6 +4,7 @@
  DocumentRoot {{ composes_local_dir }}
  #ReadmeName /centos-design/footer.html
  HeaderName /centos-design/header-centos-composes-mirror.html
+ IndexIgnoreReset ON
  IndexIgnore *~ *# HEADER* README* RCS CVS *,v *,t FOOTER.html
 
  Header always set Strict-Transport-Security "max-age=31536000"


### PR DESCRIPTION
Fix https://bugzilla.redhat.com/show_bug.cgi?id=1972750 by indexing dot-files.

NOTE: I can't test this since I don't actually have access to composes.centos.org, so I'm relying on how I _think_ this config file needs to be changed. I would definitely appreciate review and testing.

Closes: rzbz#1972750